### PR TITLE
ISSUE: Saves invocations in other collection

### DIFF
--- a/conf.js
+++ b/conf.js
@@ -1,3 +1,5 @@
+const ms = require("ms");
+
 module.exports = {
 
 	// NATS servers, set multiple if using cluster
@@ -17,6 +19,9 @@ module.exports = {
 
 	// Max failed attempts until a repeating job is considered to be failed	
 	// Is global for all jobs but this may be even more limited per job
-	maxFailures: parseInt(process.env.MAX_FAILURES || "100")
+	maxFailures: parseInt(process.env.MAX_FAILURES || "100"),
+
+	// For how long time invocations history will be saved
+	invocationsTTL: ms(process.env.INVOCATIONS_TTL || "60d")
 	
 };

--- a/lib/repos/InvocationRepo.js
+++ b/lib/repos/InvocationRepo.js
@@ -1,0 +1,29 @@
+const constants = require("../../constants");
+const uuid = require("uuid");
+
+class InvocationRepo {
+
+	constructor(db) {
+		this.collection = db.collection(constants.collections.invocations);        
+	}	
+    
+    get(id) {
+		return this.collection.findOne({id: id}, {_id: 0});
+	}
+
+	findAll() {
+		return this.collection.find({}, { _id: 0}).toArray();
+    }
+    
+	async create(jobId, invocation) {
+        invocation.id = uuid.v4();
+        invocation.jobId = jobId;
+
+        await this.collection.insert(invocation);
+        
+        return invocation;
+    }
+    	
+}
+
+module.exports = InvocationRepo;

--- a/lib/repos/JobRepo.js
+++ b/lib/repos/JobRepo.js
@@ -1,11 +1,13 @@
 const constants = require("../../constants");
+const InvocationRepo = require("./InvocationRepo");
+
 const jobStates = constants.jobStates;
 
 class JobRepo {
-
+	
 	constructor(db) {
 		this.collection = db.collection(constants.collections.jobs);
-		this.collection.createIndex({id: 1}, true);
+		this.invocationRepo = new InvocationRepo(db);
 	}
 
 	get(id) {
@@ -59,25 +61,20 @@ class JobRepo {
 	}
 
 
-	update(job, invocation) {
+	async update(job, invocation) {
 		const query = {
 			id: job.id
 		};
-
+		
 		job.updated = new Date();
 		
-		// Remove fields from update that are either incremented or pushed		
+		// Remove fields from update that are incremented
 		delete job.failureCount;
-		delete job.totalFailureCount;
-		delete job.invocations;
+		delete job.totalFailureCount;		
 		
 		let update = {
 			$set: job		
 		};
-
-		if(invocation) {
-			update.$push = { invocations: invocation };
-		}
 
 		if(job.state == jobStates.scheduled || job.state == jobStates.running) {
 			// reset failure count after success
@@ -98,8 +95,13 @@ class JobRepo {
 			}
 		};
 
-		return this.collection.findOneAndUpdate(query, update, options)
-			.then(res => res.value);
+		const updateResult = await this.collection.findOneAndUpdate(query, update, options);
+		
+		if (invocation) {
+			await this.invocationRepo.create(job.id, invocation);
+		}
+
+		return updateResult.value;			
 	}
 
 	remove(jobId) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,225 +2,314 @@
   "name": "fruster-template-js",
   "version": "0.0.1",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "add-matchers": {
-      "version": "https://registry.npmjs.org/add-matchers/-/add-matchers-0.5.0.tgz",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/add-matchers/-/add-matchers-0.5.0.tgz",
       "integrity": "sha1-UCGQ5HUM1XIWGDkyaLYaFXNm52U=",
       "dev": true
     },
     "ajv": {
-      "version": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz",
-      "integrity": "sha1-tu50ZXuZOgHc5Et5RNVvSFgo1b0="
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
     },
     "asn1": {
-      "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "assert-plus": {
-      "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-      "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "async": {
-      "version": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
       "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
     },
     "asynckit": {
-      "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sign2": {
-      "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
     "balanced-match": {
-      "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "bcrypt-pbkdf": {
-      "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
     },
     "bluebird": {
-      "version": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
-      "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "boom": {
-      "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-      "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "requires": {
+        "hoek": "4.2.0"
+      }
     },
     "brace-expansion": {
-      "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-      "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-      "dev": true
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "bson": {
-      "version": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz",
       "integrity": "sha1-k8ENOeqltYQVy8QFLz5T5WKwtyw="
     },
     "buffer-shims": {
-      "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
       "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
     },
     "capitalize": {
-      "version": "https://registry.npmjs.org/capitalize/-/capitalize-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/capitalize/-/capitalize-1.0.0.tgz",
       "integrity": "sha1-3IAsWAruEBkpAg0soUtMqKCuRL4="
     },
     "caseless": {
-      "version": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "co": {
-      "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "colors": {
-      "version": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
     "combined-stream": {
-      "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
     },
     "concat-map": {
-      "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "core-util-is": {
-      "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cron": {
-      "version": "https://registry.npmjs.org/cron/-/cron-1.2.1.tgz",
-      "integrity": "sha1-OobAm0G48mGshjp8yF6kc1hX6rI="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-1.3.0.tgz",
+      "integrity": "sha512-K/SF7JlgMmNjcThWxkKvsHhey2EDB4CeOEWJ9aXWj3fbQJppsvTPIeyLdHfNq5IbbsMUUjRW1nr5dSO95f2E4w==",
+      "requires": {
+        "moment-timezone": "0.5.14"
+      }
     },
     "cryptiles": {
-      "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-      "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g="
-    },
-    "cycle": {
-      "version": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
-    },
-    "dashdash": {
-      "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "requires": {
+        "boom": "5.2.0"
+      },
       "dependencies": {
-        "assert-plus": {
-          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        "boom": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "requires": {
+            "hoek": "4.2.0"
+          }
         }
       }
     },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "1.0.0"
+      }
+    },
     "delayed-stream": {
-      "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
-    "dezalgo": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
-      "dev": true
-    },
     "ecc-jsbn": {
-      "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-      "optional": true
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
     },
     "es6-promise": {
-      "version": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
       "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
     },
     "exit": {
-      "version": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
     "extend": {
-      "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-      "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "extsprintf": {
-      "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "eyes": {
-      "version": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
     "forever-agent": {
-      "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
-      "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
-      "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
+      }
     },
     "fruster-bus": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/fruster-bus/-/fruster-bus-0.2.7.tgz",
-      "integrity": "sha1-lpaRc3qr4rABSzC+owchFF5HcxA=",
-      "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY="
-        },
-        "fs-extra": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
-          "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU="
-        }
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/fruster-bus/-/fruster-bus-0.2.10.tgz",
+      "integrity": "sha1-DHiZefj5HEJtAi1k1TGb5kybTVM=",
+      "requires": {
+        "ajv": "4.11.8",
+        "bluebird": "3.5.1",
+        "fruster-log": "0.0.11",
+        "fs-extra": "2.1.2",
+        "lodash": "4.17.4",
+        "mock-nats-client": "0.0.3",
+        "ms": "0.7.3",
+        "nats": "0.6.8",
+        "request": "2.83.0",
+        "uuid": "2.0.3"
       }
     },
     "fruster-custom-matchers": {
-      "version": "https://registry.npmjs.org/fruster-custom-matchers/-/fruster-custom-matchers-0.0.1.tgz",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/fruster-custom-matchers/-/fruster-custom-matchers-0.0.1.tgz",
       "integrity": "sha1-G4WOJ21xoCdprxdh04EphEcyfz0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "add-matchers": "0.5.0"
+      }
     },
     "fruster-errors": {
-      "version": "https://registry.npmjs.org/fruster-errors/-/fruster-errors-0.0.7.tgz",
-      "integrity": "sha1-WyYPWvK3CYJt3/fmDjxIi9FYKdA="
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/fruster-errors/-/fruster-errors-0.0.7.tgz",
+      "integrity": "sha1-WyYPWvK3CYJt3/fmDjxIi9FYKdA=",
+      "requires": {
+        "fruster-log": "0.0.11",
+        "uuid": "2.0.3"
+      }
     },
     "fruster-health": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/fruster-health/-/fruster-health-0.0.11.tgz",
-      "integrity": "sha1-BcgstLU7fZjg5gVlX4tfWmHaIJk="
+      "integrity": "sha1-BcgstLU7fZjg5gVlX4tfWmHaIJk=",
+      "requires": {
+        "fruster-bus": "0.2.10",
+        "fruster-log": "0.0.11",
+        "ms": "0.7.3",
+        "uuid": "2.0.3"
+      }
     },
     "fruster-log": {
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/fruster-log/-/fruster-log-0.0.11.tgz",
       "integrity": "sha1-cYEQirmprPhDDftS+2UJusUmD1M=",
-      "dependencies": {
-        "moment": {
-          "version": "2.18.1",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-          "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
-        },
-        "moment-timezone": {
-          "version": "0.5.13",
-          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.13.tgz",
-          "integrity": "sha1-mc5cfYJyYusPH3AgRBd/YHRde5A="
-        }
+      "requires": {
+        "moment": "2.19.2",
+        "moment-timezone": "0.5.14",
+        "winston": "2.4.0",
+        "winston-papertrail": "1.0.5"
       }
     },
     "fruster-test-utils": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/fruster-test-utils/-/fruster-test-utils-0.3.12.tgz",
-      "integrity": "sha1-Y/WV7ZFhH/UctX/8s8LTWCjofuY=",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/fruster-test-utils/-/fruster-test-utils-0.3.17.tgz",
+      "integrity": "sha1-eTv+uCeXrUqXmLp5eYvhE0pbK6Y=",
       "dev": true,
+      "requires": {
+        "get-port": "3.2.0",
+        "jasmine": "2.8.0",
+        "jasmine-spec-reporter": "3.3.0",
+        "mongodb": "2.2.33",
+        "nats-server-control": "0.0.1",
+        "uuid": "3.1.0"
+      },
       "dependencies": {
         "colors": {
           "version": "1.1.2",
@@ -229,22 +318,24 @@
           "dev": true
         },
         "jasmine": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.7.0.tgz",
-          "integrity": "sha1-XPC7TllLRgC7QjVWA2YhKsWuobI=",
-          "dev": true
-        },
-        "jasmine-core": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.7.0.tgz",
-          "integrity": "sha1-UP+MT5LY71wLLBuEbdJj7YUVIJE=",
-          "dev": true
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.8.0.tgz",
+          "integrity": "sha1-awicChFXax8W3xG4AUbZHU6Lij4=",
+          "dev": true,
+          "requires": {
+            "exit": "0.1.2",
+            "glob": "7.1.2",
+            "jasmine-core": "2.8.0"
+          }
         },
         "jasmine-spec-reporter": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/jasmine-spec-reporter/-/jasmine-spec-reporter-3.3.0.tgz",
           "integrity": "sha1-xjw9Q7rP0W5tqGxG0mWVfgB18Uw=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "colors": "1.1.2"
+          }
         },
         "uuid": {
           "version": "3.1.0",
@@ -255,2182 +346,576 @@
       }
     },
     "fruster-validator": {
-      "version": "https://registry.npmjs.org/fruster-validator/-/fruster-validator-0.0.1.tgz",
-      "integrity": "sha1-ImAH/dqIjmJ2XdsKJXcvdPyhgiY="
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/fruster-validator/-/fruster-validator-0.0.1.tgz",
+      "integrity": "sha1-ImAH/dqIjmJ2XdsKJXcvdPyhgiY=",
+      "requires": {
+        "ajv": "4.11.8",
+        "capitalize": "1.0.0",
+        "fruster-log": "0.0.11",
+        "fs-extra": "2.1.2"
+      }
     },
     "fs-extra": {
-      "version": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.0.0.tgz",
-      "integrity": "sha1-M3NSve1KC3FPPrhN6M6nZenTdgA="
-    },
-    "fs-write-stream-atomic": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
-      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
-      "dev": true
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.1.2.tgz",
+      "integrity": "sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "2.4.0"
+      }
     },
     "fs.realpath": {
-      "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "get-port": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.1.0.tgz",
-      "integrity": "sha1-7wGxioTKZIaXD/meVERhQac//T4=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
+      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
       "dev": true
     },
     "getpass": {
-      "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-      "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
-      "dependencies": {
-        "assert-plus": {
-          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "1.0.0"
       }
     },
     "glob": {
-      "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-      "dev": true
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "glossy": {
-      "version": "https://registry.npmjs.org/glossy/-/glossy-0.1.7.tgz",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/glossy/-/glossy-0.1.7.tgz",
       "integrity": "sha1-dptZhKlvYGarnqdYIkgl7mwhDws="
     },
     "graceful-fs": {
-      "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "har-schema": {
-      "version": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio="
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "requires": {
+        "ajv": "5.3.0",
+        "har-schema": "2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+          "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        }
+      }
     },
     "hawk": {
-      "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-      "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ="
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "requires": {
+        "boom": "4.3.1",
+        "cryptiles": "3.1.2",
+        "hoek": "4.2.0",
+        "sntp": "2.1.0"
+      }
     },
     "hoek": {
-      "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
-    },
-    "hosted-git-info": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
-      "dev": true
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
     },
     "http-signature": {
-      "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-      "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8="
-    },
-    "iferr": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
-      "dev": true
-    },
-    "imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.13.1"
+      }
     },
     "inflight": {
-      "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
-      "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "is-typedarray": {
-      "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "isarray": {
-      "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isstream": {
-      "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jasmine": {
-      "version": "https://registry.npmjs.org/jasmine/-/jasmine-2.5.2.tgz",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.5.2.tgz",
       "integrity": "sha1-YoPO9whcCVzCXWUelU3wBPfj5CE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "7.1.2",
+        "jasmine-core": "2.5.2"
+      },
+      "dependencies": {
+        "jasmine-core": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.5.2.tgz",
+          "integrity": "sha1-b2G9eQYeJ/Q+b5NV5Es8bKtv8pc=",
+          "dev": true
+        }
+      }
     },
     "jasmine-core": {
-      "version": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.5.2.tgz",
-      "integrity": "sha1-b2G9eQYeJ/Q+b5NV5Es8bKtv8pc=",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.8.0.tgz",
+      "integrity": "sha1-vMl5rh+f0FcB5F5S5l06XWPxok4=",
       "dev": true
     },
     "jasmine-spec-reporter": {
-      "version": "https://registry.npmjs.org/jasmine-spec-reporter/-/jasmine-spec-reporter-2.7.0.tgz",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jasmine-spec-reporter/-/jasmine-spec-reporter-2.7.0.tgz",
       "integrity": "sha1-QpB/+ImVKhKcCvwpKeGV9OdMmP8=",
       "dev": true,
+      "requires": {
+        "colors": "1.1.2"
+      },
       "dependencies": {
         "colors": {
-          "version": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
           "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
           "dev": true
         }
       }
     },
-    "jodid25519": {
-      "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-      "optional": true
-    },
     "jsbn": {
-      "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
     },
     "json-schema": {
-      "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+    },
     "json-stable-stringify": {
-      "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "json-stringify-safe": {
-      "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsonfile": {
-      "version": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "jsonify": {
-      "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsprim": {
-      "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
-      "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
     },
     "lodash": {
-      "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lolex": {
-      "version": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
       "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
       "dev": true
     },
     "mime-db": {
-      "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz",
-      "integrity": "sha1-6v/NDk/Gk1z4E02iRuLmw1MFrf8="
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
     },
     "mime-types": {
-      "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
-      "integrity": "sha1-9+99l1g/yvO30oK2+LVnnaselO4="
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "requires": {
+        "mime-db": "1.30.0"
+      }
     },
     "minimatch": {
-      "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-      "dev": true
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "mock-nats-client": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/mock-nats-client/-/mock-nats-client-0.0.3.tgz",
+      "integrity": "sha512-00FrQKcxt71xEyMJANMOnZjKLOjVdZBRccVvfdQ4Ltbw4qwz40BFtLnPdCjYYGYCugtNPynbNlGy/LjDhJUidw==",
+      "requires": {
+        "ms": "0.7.3",
+        "uuid": "3.1.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+        }
+      }
     },
     "moment": {
-      "version": "https://registry.npmjs.org/moment/-/moment-2.17.1.tgz",
-      "integrity": "sha1-/tlQYGPzaxDwZsi1mhRNf66+HYI="
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz",
+      "integrity": "sha512-Rf6jiHPEfxp9+dlzxPTmRHbvoFXsh2L/U8hOupUMpnuecHQmI6cF6lUbJl3QqKPko1u6ujO+FxtcajLVfLpAtA=="
     },
     "moment-timezone": {
-      "version": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.11.tgz",
-      "integrity": "sha1-m3bAPY71FMfkJJp7vOZJ7tOe8p8="
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.14.tgz",
+      "integrity": "sha1-TrOP+VOLgBCLpGekWPPtQmjM/LE=",
+      "requires": {
+        "moment": "2.19.2"
+      }
     },
     "mongodb": {
-      "version": "2.2.30",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.30.tgz",
-      "integrity": "sha1-jM2AH2dsgXIEDC8rR+lgKg1WNKs=",
-      "dependencies": {
-        "mongodb-core": {
-          "version": "2.1.14",
-          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.14.tgz",
-          "integrity": "sha1-E8uidkImtb49GJkq8Mljzl6g8P0="
-        },
-        "readable-stream": {
-          "version": "2.2.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
-          "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE="
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ=="
-        }
+      "version": "2.2.33",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.33.tgz",
+      "integrity": "sha1-tTfEcdNKZlG0jzb9vyl1A0Dgi1A=",
+      "requires": {
+        "es6-promise": "3.2.1",
+        "mongodb-core": "2.1.17",
+        "readable-stream": "2.2.7"
+      }
+    },
+    "mongodb-core": {
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.17.tgz",
+      "integrity": "sha1-pBizN6FKFJkPtRC5I97mqBMXPfg=",
+      "requires": {
+        "bson": "1.0.4",
+        "require_optional": "1.0.1"
       }
     },
     "ms": {
-      "version": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.3.tgz",
       "integrity": "sha1-cIFVpeROM/X9D8U+gdDUCpG+H/8="
     },
     "nats": {
-      "version": "https://registry.npmjs.org/nats/-/nats-0.6.8.tgz",
-      "integrity": "sha1-ADLarUR8r7cyvncskZ6NzeWE0eQ="
-    },
-    "nats-server-control": {
-      "version": "https://registry.npmjs.org/nats-server-control/-/nats-server-control-0.0.1.tgz",
-      "integrity": "sha1-d/uUTxBmvJUwYO5eHaXlL/jLorA=",
-      "dev": true
-    },
-    "normalize-git-url": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/normalize-git-url/-/normalize-git-url-3.0.2.tgz",
-      "integrity": "sha1-jl8Uvgva7bc+ByADEKpBbCc1D8Q=",
-      "dev": true
-    },
-    "npm": {
-      "version": "https://registry.npmjs.org/npm/-/npm-4.4.1.tgz",
-      "integrity": "sha1-a4LUA7Nm0z9zRJIp51LA70h9mIU=",
-      "dev": true,
-      "dependencies": {
-        "abbrev": {
-          "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansicolors": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
-          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk=",
-          "dev": true
-        },
-        "ansistyles": {
-          "version": "0.1.3",
-          "resolved": "https://registry.npmjs.org/ansistyles/-/ansistyles-0.1.3.tgz",
-          "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=",
-          "dev": true
-        },
-        "aproba": {
-          "version": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
-          "dev": true
-        },
-        "archy": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
-          "dev": true
-        },
-        "asap": {
-          "version": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz",
-          "integrity": "sha1-UidltQw1EEkOUtfc/ghe+bqWlY8=",
-          "dev": true
-        },
-        "chownr": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-          "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
-          "dev": true
-        },
-        "cmd-shim": {
-          "version": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-2.0.2.tgz",
-          "integrity": "sha1-b8vamUg6j9FdfTChlspp1oii79s=",
-          "dev": true
-        },
-        "columnify": {
-          "version": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
-          "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
-          "dev": true,
-          "dependencies": {
-            "wcwidth": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.0.tgz",
-              "integrity": "sha1-AtBZ/3qPx0Hg9rXaHmmytA2uym8=",
-              "dev": true,
-              "dependencies": {
-                "defaults": {
-                  "version": "1.0.3",
-                  "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-                  "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-                  "dev": true,
-                  "dependencies": {
-                    "clone": {
-                      "version": "1.0.2",
-                      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-                      "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "config-chain": {
-          "version": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
-          "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
-          "dev": true,
-          "dependencies": {
-            "proto-list": {
-              "version": "1.2.4",
-              "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-              "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
-              "dev": true
-            }
-          }
-        },
-        "debuglog": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-          "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=",
-          "dev": true
-        },
-        "editor": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/editor/-/editor-1.0.0.tgz",
-          "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I=",
-          "dev": true
-        },
-        "fs-vacuum": {
-          "version": "https://registry.npmjs.org/fs-vacuum/-/fs-vacuum-1.2.9.tgz",
-          "integrity": "sha1-T5AZOrjqAokJlbzU6ARlml02ay0=",
-          "dev": true
-        },
-        "fstream": {
-          "version": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
-          "integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
-          "dev": true
-        },
-        "fstream-npm": {
-          "version": "https://registry.npmjs.org/fstream-npm/-/fstream-npm-1.2.0.tgz",
-          "integrity": "sha1-0sPIkQE0aYLWTlcJHDhIe9qRb84=",
-          "dev": true,
-          "dependencies": {
-            "fstream-ignore": {
-              "version": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
-              "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
-              "dev": true,
-              "dependencies": {
-                "minimatch": {
-                  "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                  "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-                  "dev": true,
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                      "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-                      "dev": true,
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-                          "dev": true
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "glob": {
-          "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-          "dev": true,
-          "dependencies": {
-            "fs.realpath": {
-              "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-              "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-              "dev": true
-            },
-            "minimatch": {
-              "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-              "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-              "dev": true,
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                  "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-                  "dev": true,
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-                      "dev": true
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-              "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-              "dev": true
-            }
-          }
-        },
-        "graceful-fs": {
-          "version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-          "dev": true
-        },
-        "has-unicode": {
-          "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-          "dev": true
-        },
-        "hosted-git-info": {
-          "version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.2.0.tgz",
-          "integrity": "sha1-eg0JeGPYhsD6u9zTe/F1jYvs+KU=",
-          "dev": true
-        },
-        "iferr": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
-          "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
-          "dev": true
-        },
-        "imurmurhash": {
-          "version": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-          "dev": true
-        },
-        "inflight": {
-          "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-          "dev": true
-        },
-        "inherits": {
-          "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
-          "dev": true
-        },
-        "init-package-json": {
-          "version": "https://registry.npmjs.org/init-package-json/-/init-package-json-1.9.4.tgz",
-          "integrity": "sha1-tAU9C0Dwz4QqQZZpN8s9wPU06FY=",
-          "dev": true,
-          "dependencies": {
-            "glob": {
-              "version": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-              "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-              "dev": true,
-              "dependencies": {
-                "minimatch": {
-                  "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                  "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-                  "dev": true,
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                      "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-                      "dev": true,
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "promzard": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/promzard/-/promzard-0.3.0.tgz",
-              "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
-              "dev": true
-            },
-            "validate-npm-package-name": {
-              "version": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-2.2.2.tgz",
-              "integrity": "sha1-9laVsi9zJEQgGaPH+jmm5/0pkIU=",
-              "dev": true,
-              "dependencies": {
-                "builtins": {
-                  "version": "https://registry.npmjs.org/builtins/-/builtins-0.0.7.tgz",
-                  "integrity": "sha1-NVIZzWzxjb58Acx/0tznZc/cVJo=",
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "JSONStream": {
-          "version": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.0.tgz",
-          "integrity": "sha1-aAq5rGVyqKGiB+CzhyHbHHeyFeU=",
-          "dev": true,
-          "dependencies": {
-            "jsonparse": {
-              "version": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
-              "integrity": "sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70=",
-              "dev": true
-            },
-            "through": {
-              "version": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-              "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-              "dev": true
-            }
-          }
-        },
-        "lazy-property": {
-          "version": "https://registry.npmjs.org/lazy-property/-/lazy-property-1.0.0.tgz",
-          "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc=",
-          "dev": true
-        },
-        "lockfile": {
-          "version": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.3.tgz",
-          "integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k=",
-          "dev": true
-        },
-        "lodash._baseindexof": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
-          "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
-          "dev": true
-        },
-        "lodash._baseuniq": {
-          "version": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz",
-          "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
-          "dev": true,
-          "dependencies": {
-            "lodash._createset": {
-              "version": "https://registry.npmjs.org/lodash._createset/-/lodash._createset-4.0.3.tgz",
-              "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=",
-              "dev": true
-            },
-            "lodash._root": {
-              "version": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-              "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
-              "dev": true
-            }
-          }
-        },
-        "lodash._bindcallback": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
-          "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
-          "dev": true
-        },
-        "lodash._cacheindexof": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
-          "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
-          "dev": true
-        },
-        "lodash._createcache": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
-          "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
-          "dev": true
-        },
-        "lodash._getnative": {
-          "version": "3.9.1",
-          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-          "dev": true
-        },
-        "lodash.clonedeep": {
-          "version": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-          "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-          "dev": true
-        },
-        "lodash.restparam": {
-          "version": "3.6.1",
-          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-          "dev": true
-        },
-        "lodash.union": {
-          "version": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-          "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=",
-          "dev": true
-        },
-        "lodash.uniq": {
-          "version": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-          "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
-          "dev": true
-        },
-        "lodash.without": {
-          "version": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
-          "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=",
-          "dev": true
-        },
-        "mississippi": {
-          "version": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
-          "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
-          "dev": true,
-          "dependencies": {
-            "concat-stream": {
-              "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-              "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-              "dev": true,
-              "dependencies": {
-                "typedarray": {
-                  "version": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                  "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-                  "dev": true
-                }
-              }
-            },
-            "duplexify": {
-              "version": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.0.tgz",
-              "integrity": "sha1-GqdzAC4VeEV+nZ1KULDMquvL1gQ=",
-              "dev": true,
-              "dependencies": {
-                "end-of-stream": {
-                  "version": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
-                  "integrity": "sha1-1FlucCc0qT5A6a+GQxnqvZn/Lw4=",
-                  "dev": true,
-                  "dependencies": {
-                    "once": {
-                      "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-                      "dev": true
-                    }
-                  }
-                },
-                "stream-shift": {
-                  "version": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-                  "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-                  "dev": true
-                }
-              }
-            },
-            "end-of-stream": {
-              "version": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
-              "integrity": "sha1-6TUyWLqpEIll78QcsO+K3i88+wc=",
-              "dev": true,
-              "dependencies": {
-                "once": {
-                  "version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                  "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
-                  "dev": true
-                }
-              }
-            },
-            "flush-write-stream": {
-              "version": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
-              "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
-              "dev": true
-            },
-            "from2": {
-              "version": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-              "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-              "dev": true
-            },
-            "parallel-transform": {
-              "version": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
-              "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
-              "dev": true,
-              "dependencies": {
-                "cyclist": {
-                  "version": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
-                  "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
-                  "dev": true
-                }
-              }
-            },
-            "pump": {
-              "version": "https://registry.npmjs.org/pump/-/pump-1.0.2.tgz",
-              "integrity": "sha1-Oz7mUS+U8OV1U4wXmV+fFpkKXVE=",
-              "dev": true
-            },
-            "pumpify": {
-              "version": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
-              "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
-              "dev": true
-            },
-            "stream-each": {
-              "version": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.0.tgz",
-              "integrity": "sha1-HpXUdXP1gNgU3A/4zQ9m8c5TyZE=",
-              "dev": true,
-              "dependencies": {
-                "stream-shift": {
-                  "version": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-                  "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-                  "dev": true
-                }
-              }
-            },
-            "through2": {
-              "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-              "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-              "dev": true,
-              "dependencies": {
-                "xtend": {
-                  "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                  "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-              "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "dev": true
-            }
-          }
-        },
-        "node-gyp": {
-          "version": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.5.0.tgz",
-          "integrity": "sha1-qP5eYR0HnsFjSKPrlg544RyFJ0o=",
-          "dev": true,
-          "dependencies": {
-            "minimatch": {
-              "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-              "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-              "dev": true,
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                  "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-                  "dev": true,
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-                      "dev": true
-                    },
-                    "concat-map": {
-                      "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "nopt": {
-              "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-              "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-              "dev": true
-            }
-          }
-        },
-        "nopt": {
-          "version": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-          "dev": true,
-          "dependencies": {
-            "osenv": {
-              "version": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-              "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-              "dev": true,
-              "dependencies": {
-                "os-homedir": {
-                  "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-                  "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-                  "dev": true
-                },
-                "os-tmpdir": {
-                  "version": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-                  "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "normalize-package-data": {
-          "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
-          "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
-          "dev": true,
-          "dependencies": {
-            "is-builtin-module": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-              "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-              "dev": true,
-              "dependencies": {
-                "builtin-modules": {
-                  "version": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-                  "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "npm-cache-filename": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/npm-cache-filename/-/npm-cache-filename-1.0.2.tgz",
-          "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE=",
-          "dev": true
-        },
-        "npm-package-arg": {
-          "version": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.2.0.tgz",
-          "integrity": "sha1-gJvGHKv1S9X/lPYWXIm6juiMEVw=",
-          "dev": true
-        },
-        "npm-registry-client": {
-          "version": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-7.4.5.tgz",
-          "integrity": "sha1-HvYYUbtyMdtT45eq923fHLZFw98=",
-          "dev": true,
-          "dependencies": {
-            "concat-stream": {
-              "version": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
-              "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
-              "dev": true,
-              "dependencies": {
-                "readable-stream": {
-                  "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-                  "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-                  "dev": true,
-                  "dependencies": {
-                    "process-nextick-args": {
-                      "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-                      "dev": true
-                    }
-                  }
-                },
-                "typedarray": {
-                  "version": "0.0.6",
-                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-                  "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "npm-user-validate": {
-          "version": "https://registry.npmjs.org/npm-user-validate/-/npm-user-validate-0.1.5.tgz",
-          "integrity": "sha1-UkZdUMLSApSlcSW5lrrtv1bFAEs=",
-          "dev": true
-        },
-        "npmlog": {
-          "version": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
-          "integrity": "sha1-0DlQ4OeM4VJ7om0qdZLpNIrD518=",
-          "dev": true,
-          "dependencies": {
-            "are-we-there-yet": {
-              "version": "http://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
-              "integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
-              "dev": true,
-              "dependencies": {
-                "delegates": {
-                  "version": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-                  "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-                  "dev": true
-                }
-              }
-            },
-            "console-control-strings": {
-              "version": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-              "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-              "dev": true
-            },
-            "gauge": {
-              "version": "https://registry.npmjs.org/gauge/-/gauge-2.7.2.tgz",
-              "integrity": "sha1-Fc7MMbAtBTRaXWsOFxzbOtIwd3Q=",
-              "dev": true,
-              "dependencies": {
-                "object-assign": {
-                  "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-                  "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
-                  "dev": true
-                },
-                "signal-exit": {
-                  "version": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-                  "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-                  "dev": true
-                },
-                "string-width": {
-                  "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                  "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                  "dev": true,
-                  "dependencies": {
-                    "code-point-at": {
-                      "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                      "dev": true
-                    },
-                    "is-fullwidth-code-point": {
-                      "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                      "dev": true,
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-                  "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
-                  "dev": true
-                },
-                "wide-align": {
-                  "version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
-                  "integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
-                  "dev": true
-                }
-              }
-            },
-            "set-blocking": {
-              "version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-              "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-              "dev": true
-            }
-          }
-        },
-        "once": {
-          "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-          "dev": true
-        },
-        "opener": {
-          "version": "https://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
-          "integrity": "sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=",
-          "dev": true
-        },
-        "osenv": {
-          "version": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-          "dev": true,
-          "dependencies": {
-            "os-homedir": {
-              "version": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-              "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-              "dev": true
-            },
-            "os-tmpdir": {
-              "version": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-              "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-              "dev": true
-            }
-          }
-        },
-        "path-is-inside": {
-          "version": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
-          "dev": true
-        },
-        "read": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-          "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-          "dev": true,
-          "dependencies": {
-            "mute-stream": {
-              "version": "0.0.5",
-              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-              "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
-              "dev": true
-            }
-          }
-        },
-        "read-cmd-shim": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.1.tgz",
-          "integrity": "sha1-LV0Vd4ajfAVdIgd8MsU/gynpHHs=",
-          "dev": true
-        },
-        "read-installed": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
-          "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
-          "dev": true,
-          "dependencies": {
-            "util-extend": {
-              "version": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
-              "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=",
-              "dev": true
-            }
-          }
-        },
-        "read-package-json": {
-          "version": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.4.tgz",
-          "integrity": "sha1-Ye0bIlbqQ42ACIlQkL6EuOeZyFM=",
-          "dev": true,
-          "dependencies": {
-            "glob": {
-              "version": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-              "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-              "dev": true,
-              "dependencies": {
-                "minimatch": {
-                  "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                  "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-                  "dev": true,
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
-                      "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-                      "dev": true,
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "json-parse-helpfulerror": {
-              "version": "1.0.3",
-              "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
-              "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w=",
-              "dev": true,
-              "dependencies": {
-                "jju": {
-                  "version": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
-                  "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo=",
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "read-package-tree": {
-          "version": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.5.tgz",
-          "integrity": "sha1-rOfmOBx2hPlwqqmPx8XStmat2rY=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.3.tgz",
-          "integrity": "sha1-nPSUY5hd8BbIrogTCXqSk6mzNyk=",
-          "dev": true,
-          "dependencies": {
-            "buffer-shims": {
-              "version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-              "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
-              "dev": true
-            },
-            "isarray": {
-              "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-              "dev": true
-            },
-            "process-nextick-args": {
-              "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-              "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-              "dev": true
-            },
-            "util-deprecate": {
-              "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-              "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-              "dev": true
-            }
-          }
-        },
-        "readdir-scoped-modules": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
-          "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
-          "dev": true
-        },
-        "request": {
-          "version": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-          "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-          "dev": true,
-          "dependencies": {
-            "aws-sign2": {
-              "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-              "dev": true
-            },
-            "aws4": {
-              "version": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
-              "integrity": "sha1-Cin/t5wxyecS7rCH6OemS0pW11U=",
-              "dev": true
-            },
-            "caseless": {
-              "version": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-              "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
-              "dev": true
-            },
-            "combined-stream": {
-              "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-              "dev": true,
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-                  "dev": true
-                }
-              }
-            },
-            "extend": {
-              "version": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
-              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
-              "dev": true
-            },
-            "forever-agent": {
-              "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-              "dev": true
-            },
-            "form-data": {
-              "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
-              "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
-              "dev": true,
-              "dependencies": {
-                "asynckit": {
-                  "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-                  "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-                  "dev": true
-                }
-              }
-            },
-            "har-validator": {
-              "version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-              "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
-              "dev": true,
-              "dependencies": {
-                "chalk": {
-                  "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                  "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-                  "dev": true,
-                  "dependencies": {
-                    "ansi-styles": {
-                      "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                      "dev": true
-                    },
-                    "escape-string-regexp": {
-                      "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-                      "dev": true
-                    },
-                    "has-ansi": {
-                      "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-                      "dev": true
-                    },
-                    "supports-color": {
-                      "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                      "dev": true
-                    }
-                  }
-                },
-                "commander": {
-                  "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                  "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-                  "dev": true,
-                  "dependencies": {
-                    "graceful-readlink": {
-                      "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-                      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
-                      "dev": true
-                    }
-                  }
-                },
-                "is-my-json-valid": {
-                  "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-                  "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
-                  "dev": true,
-                  "dependencies": {
-                    "generate-function": {
-                      "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-                      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-                      "dev": true
-                    },
-                    "generate-object-property": {
-                      "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-                      "dev": true,
-                      "dependencies": {
-                        "is-property": {
-                          "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-                          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-                          "dev": true
-                        }
-                      }
-                    },
-                    "jsonpointer": {
-                      "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz",
-                      "integrity": "sha1-ZmHhYdL8RF8Z+YQwIxNDci4fy9U=",
-                      "dev": true
-                    },
-                    "xtend": {
-                      "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-                      "dev": true
-                    }
-                  }
-                },
-                "pinkie-promise": {
-                  "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                  "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-                  "dev": true,
-                  "dependencies": {
-                    "pinkie": {
-                      "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-                      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "hawk": {
-              "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-              "dev": true,
-              "dependencies": {
-                "boom": {
-                  "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                  "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-                  "dev": true
-                },
-                "cryptiles": {
-                  "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                  "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-                  "dev": true
-                },
-                "hoek": {
-                  "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                  "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-                  "dev": true
-                },
-                "sntp": {
-                  "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-                  "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-                  "dev": true
-                }
-              }
-            },
-            "http-signature": {
-              "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-              "dev": true,
-              "dependencies": {
-                "assert-plus": {
-                  "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                  "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-                  "dev": true
-                },
-                "jsprim": {
-                  "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
-                  "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
-                  "dev": true,
-                  "dependencies": {
-                    "extsprintf": {
-                      "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
-                      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-                      "dev": true
-                    },
-                    "json-schema": {
-                      "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-                      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-                      "dev": true
-                    },
-                    "verror": {
-                      "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-                      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
-                      "dev": true
-                    }
-                  }
-                },
-                "sshpk": {
-                  "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
-                  "integrity": "sha1-MOGl0ykkSXShr2FREznVla9mOLA=",
-                  "dev": true,
-                  "dependencies": {
-                    "asn1": {
-                      "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-                      "dev": true
-                    },
-                    "assert-plus": {
-                      "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                      "dev": true
-                    },
-                    "bcrypt-pbkdf": {
-                      "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
-                      "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
-                      "dev": true,
-                      "optional": true
-                    },
-                    "dashdash": {
-                      "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-                      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-                      "dev": true
-                    },
-                    "ecc-jsbn": {
-                      "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-                      "dev": true,
-                      "optional": true
-                    },
-                    "getpass": {
-                      "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
-                      "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
-                      "dev": true
-                    },
-                    "jodid25519": {
-                      "version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
-                      "dev": true,
-                      "optional": true
-                    },
-                    "jsbn": {
-                      "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                      "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
-                      "dev": true,
-                      "optional": true
-                    },
-                    "tweetnacl": {
-                      "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
-                      "integrity": "sha1-PaOC9nDyXe1417PReSEZvKC3Ey0=",
-                      "dev": true,
-                      "optional": true
-                    }
-                  }
-                }
-              }
-            },
-            "is-typedarray": {
-              "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-              "dev": true
-            },
-            "isstream": {
-              "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-              "dev": true
-            },
-            "json-stringify-safe": {
-              "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-              "dev": true
-            },
-            "mime-types": {
-              "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.13.tgz",
-              "integrity": "sha1-4HqqnGxrmnyjASxpADrSWjnpKog=",
-              "dev": true,
-              "dependencies": {
-                "mime-db": {
-                  "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.25.0.tgz",
-                  "integrity": "sha1-wY29fHOl2/b0SgJNwNFloeexw5I=",
-                  "dev": true
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
-              "dev": true
-            },
-            "qs": {
-              "version": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
-              "integrity": "sha1-9AOyZPI7wBIox0ExtAfxjV6l1EI=",
-              "dev": true
-            },
-            "stringstream": {
-              "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-              "dev": true
-            },
-            "tough-cookie": {
-              "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-              "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-              "dev": true,
-              "dependencies": {
-                "punycode": {
-                  "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                  "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-                  "dev": true
-                }
-              }
-            },
-            "tunnel-agent": {
-              "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-              "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-              "dev": true
-            }
-          }
-        },
-        "retry": {
-          "version": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-          "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.0.tgz",
-          "integrity": "sha1-ibig/kMrn/nsmpJaALbNs6kbuto=",
-          "dev": true
-        },
-        "semver": {
-          "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
-          "dev": true
-        },
-        "sha": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/sha/-/sha-2.0.1.tgz",
-          "integrity": "sha1-YDCCL70smCOUn49y7WQR7lzyWq4=",
-          "dev": true
-        },
-        "slide": {
-          "version": "1.1.6",
-          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-          "dev": true
-        },
-        "sorted-object": {
-          "version": "https://registry.npmjs.org/sorted-object/-/sorted-object-2.0.1.tgz",
-          "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw=",
-          "dev": true
-        },
-        "sorted-union-stream": {
-          "version": "https://registry.npmjs.org/sorted-union-stream/-/sorted-union-stream-2.1.3.tgz",
-          "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
-          "dev": true,
-          "dependencies": {
-            "from2": {
-              "version": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
-              "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
-              "dev": true,
-              "dependencies": {
-                "readable-stream": {
-                  "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                  "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-                  "dev": true,
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-                      "dev": true
-                    },
-                    "isarray": {
-                      "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                      "dev": true
-                    },
-                    "string_decoder": {
-                      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "stream-iterate": {
-              "version": "https://registry.npmjs.org/stream-iterate/-/stream-iterate-1.1.1.tgz",
-              "integrity": "sha1-XX0ZeqUryeJxtEVHyeOIsrGzODY=",
-              "dev": true
-            }
-          }
-        },
-        "strip-ansi": {
-          "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-          "dev": true,
-          "dependencies": {
-            "block-stream": {
-              "version": "0.0.8",
-              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz",
-              "integrity": "sha1-Boj0baK7+c/wxPaCJaDLlcvopGs=",
-              "dev": true
-            }
-          }
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-          "dev": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
-          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
-          "dev": true
-        },
-        "umask": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/umask/-/umask-1.1.0.tgz",
-          "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0=",
-          "dev": true
-        },
-        "unique-filename": {
-          "version": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
-          "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
-          "dev": true
-        },
-        "unpipe": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-          "dev": true
-        },
-        "update-notifier": {
-          "version": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.0.0.tgz",
-          "integrity": "sha1-HycS/SB59BWYC1r5XrEg5KzuqaY=",
-          "dev": true,
-          "dependencies": {
-            "boxen": {
-              "version": "https://registry.npmjs.org/boxen/-/boxen-1.0.0.tgz",
-              "integrity": "sha1-smlLrx9gX3CP8Bd8Ehk7IvKaqqs=",
-              "dev": true,
-              "dependencies": {
-                "ansi-align": {
-                  "version": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
-                  "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
-                  "dev": true,
-                  "dependencies": {
-                    "string-width": {
-                      "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                      "dev": true,
-                      "dependencies": {
-                        "code-point-at": {
-                          "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                          "dev": true
-                        },
-                        "is-fullwidth-code-point": {
-                          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                          "dev": true,
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "camelcase": {
-                  "version": "https://registry.npmjs.org/camelcase/-/camelcase-4.0.0.tgz",
-                  "integrity": "sha1-iw+Q1Evl4oG5A7mIc0m5JZXvB/I=",
-                  "dev": true
-                },
-                "cli-boxes": {
-                  "version": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-                  "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
-                  "dev": true
-                },
-                "string-width": {
-                  "version": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-                  "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
-                  "dev": true,
-                  "dependencies": {
-                    "is-fullwidth-code-point": {
-                      "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                      "dev": true
-                    }
-                  }
-                },
-                "term-size": {
-                  "version": "https://registry.npmjs.org/term-size/-/term-size-0.1.1.tgz",
-                  "integrity": "sha1-hzYLljlsq1dgljcUzaDQy+7K2co=",
-                  "dev": true,
-                  "dependencies": {
-                    "execa": {
-                      "version": "https://registry.npmjs.org/execa/-/execa-0.4.0.tgz",
-                      "integrity": "sha1-TrZGejaglfq7KXD/nV4/t7zm68M=",
-                      "dev": true,
-                      "dependencies": {
-                        "cross-spawn-async": {
-                          "version": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
-                          "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
-                          "dev": true,
-                          "dependencies": {
-                            "lru-cache": {
-                              "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
-                              "integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
-                              "dev": true,
-                              "dependencies": {
-                                "pseudomap": {
-                                  "version": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-                                  "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-                                  "dev": true
-                                },
-                                "yallist": {
-                                  "version": "https://registry.npmjs.org/yallist/-/yallist-2.0.0.tgz",
-                                  "integrity": "sha1-MGxUODXwnuGkyyO3vOmrNByRzdQ=",
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "is-stream": {
-                          "version": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-                          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-                          "dev": true
-                        },
-                        "npm-run-path": {
-                          "version": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
-                          "integrity": "sha1-9cMr9ZX+ga6Sfa7FLoL4sACsPI8=",
-                          "dev": true
-                        },
-                        "object-assign": {
-                          "version": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-                          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-                          "dev": true
-                        },
-                        "path-key": {
-                          "version": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
-                          "integrity": "sha1-XVPVeAGWRsDWiADbThRua9wqx68=",
-                          "dev": true
-                        },
-                        "strip-eof": {
-                          "version": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-                          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "widest-line": {
-                  "version": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
-                  "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
-                  "dev": true,
-                  "dependencies": {
-                    "string-width": {
-                      "version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                      "dev": true,
-                      "dependencies": {
-                        "code-point-at": {
-                          "version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-                          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-                          "dev": true
-                        },
-                        "is-fullwidth-code-point": {
-                          "version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                          "dev": true,
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-                              "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "chalk": {
-              "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-              "dev": true,
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                  "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-                  "dev": true
-                },
-                "escape-string-regexp": {
-                  "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                  "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-                  "dev": true
-                },
-                "has-ansi": {
-                  "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-                  "dev": true
-                },
-                "supports-color": {
-                  "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                  "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-                  "dev": true
-                }
-              }
-            },
-            "configstore": {
-              "version": "https://registry.npmjs.org/configstore/-/configstore-3.0.0.tgz",
-              "integrity": "sha1-4bhmnBgDzMULVF6S+ObnmqgOAZY=",
-              "dev": true,
-              "dependencies": {
-                "dot-prop": {
-                  "version": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.1.0.tgz",
-                  "integrity": "sha1-6ynqxX36Mf2h7e9Q6kYu49OP86s=",
-                  "dev": true,
-                  "dependencies": {
-                    "is-obj": {
-                      "version": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-                      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-                      "dev": true
-                    }
-                  }
-                },
-                "unique-string": {
-                  "version": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
-                  "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-                  "dev": true,
-                  "dependencies": {
-                    "crypto-random-string": {
-                      "version": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-                      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
-                      "dev": true
-                    }
-                  }
-                }
-              }
-            },
-            "is-npm": {
-              "version": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-              "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
-              "dev": true
-            },
-            "latest-version": {
-              "version": "https://registry.npmjs.org/latest-version/-/latest-version-3.0.0.tgz",
-              "integrity": "sha1-MQTwCMDDkQhBB/haNEvGHjiXBkk=",
-              "dev": true,
-              "dependencies": {
-                "package-json": {
-                  "version": "https://registry.npmjs.org/package-json/-/package-json-3.0.0.tgz",
-                  "integrity": "sha1-3BH3nr20NuVf4rmylO4/KoejOxM=",
-                  "dev": true,
-                  "dependencies": {
-                    "got": {
-                      "version": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-                      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-                      "dev": true,
-                      "dependencies": {
-                        "create-error-class": {
-                          "version": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-                          "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-                          "dev": true,
-                          "dependencies": {
-                            "capture-stack-trace": {
-                              "version": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-                              "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
-                              "dev": true
-                            }
-                          }
-                        },
-                        "duplexer3": {
-                          "version": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
-                          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-                          "dev": true
-                        },
-                        "get-stream": {
-                          "version": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-                          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-                          "dev": true
-                        },
-                        "is-redirect": {
-                          "version": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-                          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-                          "dev": true
-                        },
-                        "is-retry-allowed": {
-                          "version": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-                          "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
-                          "dev": true
-                        },
-                        "is-stream": {
-                          "version": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-                          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-                          "dev": true
-                        },
-                        "lowercase-keys": {
-                          "version": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-                          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
-                          "dev": true
-                        },
-                        "safe-buffer": {
-                          "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-                          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-                          "dev": true
-                        },
-                        "timed-out": {
-                          "version": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-                          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-                          "dev": true
-                        },
-                        "unzip-response": {
-                          "version": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-                          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-                          "dev": true
-                        },
-                        "url-parse-lax": {
-                          "version": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-                          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-                          "dev": true,
-                          "dependencies": {
-                            "prepend-http": {
-                              "version": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-                              "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "registry-auth-token": {
-                      "version": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.1.0.tgz",
-                      "integrity": "sha1-mXwIJW4MeZmDe5DpRNs52KeQJ2s=",
-                      "dev": true,
-                      "dependencies": {
-                        "rc": {
-                          "version": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-                          "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
-                          "dev": true,
-                          "dependencies": {
-                            "deep-extend": {
-                              "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-                              "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
-                              "dev": true
-                            },
-                            "minimist": {
-                              "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                              "dev": true
-                            },
-                            "strip-json-comments": {
-                              "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-                              "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "registry-url": {
-                      "version": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-                      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-                      "dev": true,
-                      "dependencies": {
-                        "rc": {
-                          "version": "https://registry.npmjs.org/rc/-/rc-1.1.6.tgz",
-                          "integrity": "sha1-Q2UbdrauU7XIAvEVH6P8OwWZack=",
-                          "dev": true,
-                          "dependencies": {
-                            "deep-extend": {
-                              "version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
-                              "integrity": "sha1-7+QRPQgIX05vlod1mBD4B0aeIlM=",
-                              "dev": true
-                            },
-                            "minimist": {
-                              "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                              "dev": true
-                            },
-                            "strip-json-comments": {
-                              "version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-                              "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "lazy-req": {
-              "version": "https://registry.npmjs.org/lazy-req/-/lazy-req-2.0.0.tgz",
-              "integrity": "sha1-yUUKNj7N2i5vDHATKtTzf48G8rQ=",
-              "dev": true
-            },
-            "semver-diff": {
-              "version": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
-              "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-              "dev": true
-            },
-            "xdg-basedir": {
-              "version": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-              "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
-              "dev": true
-            }
-          }
-        },
-        "uuid": {
-          "version": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
-          "dev": true
-        },
-        "validate-npm-package-license": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-          "dev": true,
-          "dependencies": {
-            "spdx-correct": {
-              "version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-              "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-              "dev": true,
-              "dependencies": {
-                "spdx-license-ids": {
-                  "version": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.0.tgz",
-                  "integrity": "sha1-tUndD2Pct0Whfi6joHQC4OMy0eI=",
-                  "dev": true
-                }
-              }
-            },
-            "spdx-expression-parse": {
-              "version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.2.tgz",
-              "integrity": "sha1-1SsUtelnB3FECvIlvLVjEirEUvY=",
-              "dev": true,
-              "dependencies": {
-                "spdx-exceptions": {
-                  "version": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-1.0.4.tgz",
-                  "integrity": "sha1-IguEI5EZrpBFqJLbgag/TOFvgP0=",
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "validate-npm-package-name": {
-          "version": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-          "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
-          "dev": true,
-          "dependencies": {
-            "builtins": {
-              "version": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-              "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og=",
-              "dev": true
-            }
-          }
-        },
-        "which": {
-          "version": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
-          "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
-          "dev": true,
-          "dependencies": {
-            "isexe": {
-              "version": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
-              "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA=",
-              "dev": true
-            }
-          }
-        },
-        "wrappy": {
-          "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
-        },
-        "write-file-atomic": {
-          "version": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.1.tgz",
-          "integrity": "sha1-fUW6MjFjKN0ex9kPYOvA2EW7dZo=",
-          "dev": true
-        }
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/nats/-/nats-0.6.8.tgz",
+      "integrity": "sha1-ADLarUR8r7cyvncskZ6NzeWE0eQ=",
+      "requires": {
+        "nuid": "0.6.14"
       }
     },
-    "npm-install-checks": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-3.0.0.tgz",
-      "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc=",
-      "dev": true
-    },
-    "npm-package-arg": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-4.2.1.tgz",
-      "integrity": "sha1-WTMD/eqF98Qid18X+et2cPaA4+w=",
-      "dev": true
+    "nats-server-control": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/nats-server-control/-/nats-server-control-0.0.1.tgz",
+      "integrity": "sha1-d/uUTxBmvJUwYO5eHaXlL/jLorA=",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1"
+      }
     },
     "nuid": {
-      "version": "https://registry.npmjs.org/nuid/-/nuid-0.6.8.tgz",
-      "integrity": "sha1-UfIgq5JjPZFN62a7H2BS0R8HzRc="
+      "version": "0.6.14",
+      "resolved": "https://registry.npmjs.org/nuid/-/nuid-0.6.14.tgz",
+      "integrity": "sha1-oiXItyDkbFY62NE2QTaGafbCW0g="
     },
     "oauth-sign": {
-      "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
     "once": {
-      "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "path-is-absolute": {
-      "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "performance-now": {
-      "version": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "process-nextick-args": {
-      "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
     "punycode": {
-      "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
-      "version": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "readable-stream": {
-      "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-      "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
-      "dev": true
-    },
-    "realize-package-specifier": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/realize-package-specifier/-/realize-package-specifier-3.0.3.tgz",
-      "integrity": "sha1-0N74gpUrjeP2frpekRmWYScfQfQ=",
-      "dev": true
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
+      "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
+      "requires": {
+        "buffer-shims": "1.0.0",
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
     },
     "request": {
-      "version": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+      "version": "2.83.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "requires": {
+        "aws-sign2": "0.7.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.1",
+        "har-validator": "5.0.3",
+        "hawk": "6.0.2",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.17",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.1",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.3",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.1.0"
+      },
       "dependencies": {
         "uuid": {
-          "version": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
-          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
         }
       }
     },
     "require_optional": {
-      "version": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
-      "integrity": "sha1-UqhhN6hJco62ClVTNhf4+RT1mr8="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "requires": {
+        "resolve-from": "2.0.0",
+        "semver": "5.4.1"
+      }
     },
     "resolve-from": {
-      "version": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
       "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
     },
     "safe-buffer": {
-      "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "semver": {
-      "version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "sntp": {
-      "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-      "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg="
-    },
-    "spdx-license-ids": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "requires": {
+        "hoek": "4.2.0"
+      }
     },
     "sshpk": {
-      "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.11.0.tgz",
-      "integrity": "sha1-LY1eu0pvqyj/ujf6YqkPSj6lnXc=",
-      "dependencies": {
-        "assert-plus": {
-          "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        }
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
       }
     },
     "stack-trace": {
-      "version": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
-      "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU="
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "string_decoder": {
-      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-      "dev": true
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "stringstream": {
-      "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
       "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
     },
     "tough-cookie": {
-      "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo="
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "requires": {
+        "punycode": "1.4.1"
+      }
     },
     "tunnel-agent": {
-      "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "tweetnacl": {
-      "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
     },
-    "unique-slug": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
-      "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
-      "dev": true
-    },
     "util-deprecate": {
-      "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
       "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
     },
     "verror": {
-      "version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
-      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      }
     },
     "winston": {
-      "version": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
-      "integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
+      "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
+      "requires": {
+        "async": "1.0.0",
+        "colors": "1.0.3",
+        "cycle": "1.0.3",
+        "eyes": "0.1.8",
+        "isstream": "0.1.2",
+        "stack-trace": "0.0.10"
+      }
     },
     "winston-papertrail": {
-      "version": "https://registry.npmjs.org/winston-papertrail/-/winston-papertrail-1.0.4.tgz",
-      "integrity": "sha1-lbQOL1GM8Sl1IHsnLKqwjI6kSPk="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/winston-papertrail/-/winston-papertrail-1.0.5.tgz",
+      "integrity": "sha1-VKI7FuUEZlK/aHs33IAnFL/UYsk=",
+      "requires": {
+        "glossy": "0.1.7"
+      }
     },
     "wrappy": {
-      "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "cron": "^1.2.1",
-    "fruster-bus": "^0.2.7",
+    "fruster-bus": "^0.2.10",
     "fruster-errors": "0.0.7",
     "fruster-health": "0.0.11",
     "fruster-log": "0.0.11",
@@ -20,12 +20,12 @@
   },
   "devDependencies": {
     "fruster-custom-matchers": "0.0.1",
-    "fruster-test-utils": "^0.3.12",
+    "fruster-test-utils": "^0.3.17",
     "jasmine": "2.5.2",
     "jasmine-spec-reporter": "2.7.0",
     "lolex": "^1.6.0"
   },
   "engines": {
-    "node": "6.4.0"
+    "node": "7.10.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,58 @@
 # Fruster schedule service
 
-Service for scheduling jobs by date or cron job.
+Service that runs jobs on a given interval or time.
 
-See `service.yaml` for details.
+Job state is persisted for logging and retry logic (depending on job configuration).
+
+Fruster job service uses database for locking a job so only one execution is guarenteed. However
+it is recommended that any jobs that are triggered are idempotent.
+
+
+## Exposing
+
+### `schedule-service.create-job`
+
+Creates or updates (upserts) a new job.
+
+
+#### Example requests
+
+Create a job that will be fired every day at 10 am
+
+```
+{
+    "reqId": "89b9e6b7-76ac-4817-8e27-c1d2d0bd13c8",
+    "data": {
+        // Unique id of job, if none is provided a UUID will be created
+        "id": "send",
+
+        // Optional display name of job
+        "name": "Daily usage report"
+        
+        // Optional description of job
+        "description": "Sends out daily usage report via email to admins",
+        
+        // Subject to invoke
+        "subject": "analytics-service.send-report",
+
+        // Optional data object that will be included in 
+        "data": {},
+        
+        // Optional tags
+        "tags": [ "analytics" ],
+            
+        // Cron pattern that describes when job will run
+        "cron": "* * * * * *",
+        
+        // If job should be triggered once by date
+        "at": "2017-02-23T16:00:00"                                                      
+    }
+}
+```
+
+## Configuration
+
+See `conf.js`.
 
 ## Roadmap
 

--- a/spec/CreateJobHandler.spec.js
+++ b/spec/CreateJobHandler.spec.js
@@ -11,6 +11,7 @@ describe("CreateJobHandler", () => {
 		mongoUrl: "mongodb://localhost:27017/schedule-service-test",
 		service: scheduleService,
 		bus: bus,
+		mockNats: true,
 		afterStart: (connection) => {
 			return Promise.resolve();
 		}

--- a/spec/JobRepo.spec.js
+++ b/spec/JobRepo.spec.js
@@ -102,8 +102,7 @@ describe("JobRepo", () => {
 			.then(updatedJob => {
 				expect(updatedJob.lastFailure).toBeDefined();			
 				expect(updatedJob.failureCount).toBe(1);							
-				expect(updatedJob.totalFailureCount).toBe(1);							
-				expect(updatedJob.invocations.length).toBe(1);							
+				expect(updatedJob.totalFailureCount).toBe(1);											
 				return repo.update(updatedJob, {aInvocation: ""});
 			})
 			.then(updatedJob => {

--- a/spec/RemoveJobHandler.spec.js
+++ b/spec/RemoveJobHandler.spec.js
@@ -11,6 +11,7 @@ describe("RemoveJobHandler", () => {
 		mongoUrl: "mongodb://localhost:27017/schedule-service-test",
 		service: scheduleService,
 		bus: bus,
+		mockNats: true,
 		afterStart: (connection) => {
 			return Promise.resolve();
 		}


### PR DESCRIPTION
Saves invocations in separate collection so job document does not get to big (previously all invocations were pushed onto an array on `job`).

Also add config `INVOCATIONS_TTL` to limit for how long invocations are stored.

This PR is not breaking but all usages schedule service should at some point manually recreate any existing jobs to get a fresh start. 